### PR TITLE
Fix #43: add tests for client

### DIFF
--- a/.github/workflows/sheth-test.yaml
+++ b/.github/workflows/sheth-test.yaml
@@ -15,3 +15,4 @@ jobs:
     - name: Run tests
       run: 
         cargo test --release --verbose
+        cargo test --manifest-path=client/Cargo.toml --release

--- a/client/src/client/command.rs
+++ b/client/src/client/command.rs
@@ -11,8 +11,7 @@ use std::collections::HashMap;
 
 /// A enum that describes the possible commands a user might send to the client and their required
 /// arguments.
-#[derive(Debug)]
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum Command {
     Balance(BalanceCmd),
     Transfer(TransferCmd),
@@ -21,15 +20,13 @@ pub enum Command {
 }
 
 /// The balance command will return the balance of a specified address.
-#[derive(Debug)]
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct BalanceCmd {
     pub(crate) address: U256,
 }
 
 /// The transfer command will transfer some amount from one specified account to another.
-#[derive(Debug)]
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct TransferCmd {
     pub(crate) from: U256,
     pub(crate) to: U256,
@@ -37,8 +34,7 @@ pub struct TransferCmd {
 }
 
 /// The accounts command will list the accounts managed by the client.
-#[derive(Debug)]
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub struct AccountsCmd();
 
 impl BalanceCmd {

--- a/client/src/client/command.rs
+++ b/client/src/client/command.rs
@@ -11,6 +11,8 @@ use std::collections::HashMap;
 
 /// A enum that describes the possible commands a user might send to the client and their required
 /// arguments.
+#[derive(Debug)]
+#[derive(PartialEq)]
 pub enum Command {
     Balance(BalanceCmd),
     Transfer(TransferCmd),
@@ -19,11 +21,15 @@ pub enum Command {
 }
 
 /// The balance command will return the balance of a specified address.
+#[derive(Debug)]
+#[derive(PartialEq)]
 pub struct BalanceCmd {
     pub(crate) address: U256,
 }
 
 /// The transfer command will transfer some amount from one specified account to another.
+#[derive(Debug)]
+#[derive(PartialEq)]
 pub struct TransferCmd {
     pub(crate) from: U256,
     pub(crate) to: U256,
@@ -31,6 +37,8 @@ pub struct TransferCmd {
 }
 
 /// The accounts command will list the accounts managed by the client.
+#[derive(Debug)]
+#[derive(PartialEq)]
 pub struct AccountsCmd();
 
 impl BalanceCmd {

--- a/client/src/client/error.rs
+++ b/client/src/client/error.rs
@@ -1,5 +1,6 @@
 /// An enum of errors that can occur while running a client.
 #[derive(Debug)]
+#[derive(PartialEq)]
 pub enum Error {
     /// Unable to parse command string into a new command
     CommandUnknown(String),

--- a/client/src/client/error.rs
+++ b/client/src/client/error.rs
@@ -1,6 +1,5 @@
 /// An enum of errors that can occur while running a client.
-#[derive(Debug)]
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum Error {
     /// Unable to parse command string into a new command
     CommandUnknown(String),

--- a/client/src/client/parse.rs
+++ b/client/src/client/parse.rs
@@ -69,3 +69,238 @@ pub fn parse_address(s: &str) -> Result<U256, Error> {
         Ok(U256::from(array_ref![bytes, 0, 32]))
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const ADDRESS: &str = "b94F5eA0ba39494cE839613fffBA74279579268A742795792683424567896523";
+    const PARSED_ADDRESS: [u8; 32] = [
+        185, 79, 94, 160, 186, 57, 73, 76, 232, 57, 97, 63, 255, 186, 116, 39, 149, 121, 38, 138,
+        116, 39, 149, 121, 38, 131, 66, 69, 103, 137, 101, 35,
+    ];
+
+    fn create_correct_balance_arguments<'a>() -> Vec<&'a str> {
+        let mut arguments = vec!();
+        arguments.push(ADDRESS);
+        arguments
+    }
+
+    fn create_correct_balance() -> BalanceCmd {
+        let address = U256::from(PARSED_ADDRESS);
+        BalanceCmd { address }
+    }
+
+    fn create_correct_transfer() -> TransferCmd {
+        let from_to = U256::from(PARSED_ADDRESS);
+        TransferCmd {
+            from: from_to,
+            to: from_to,
+            amount: 34,
+        }
+    }
+
+    fn create_correct_transfer_arguments<'a>() -> Vec<&'a str> {
+        let mut arguments = vec!();
+        arguments.push(ADDRESS);
+        arguments.push(ADDRESS);
+        arguments.push("34");
+        arguments
+    }
+
+    macro_rules! assert_arguments_incorrect {
+        ($arguments_expr: expr, $parser_expr: expr, $error_string_expr: expr) => {
+            assert_eq!(
+                $parser_expr($arguments_expr).unwrap_err(),
+                Error::ArgumentsIncorrect($error_string_expr.to_string())
+            )
+        };
+    }
+
+    macro_rules! assert_address_ok {
+        ($address_expr: expr, $expected_expr: expr) => {
+            assert_eq!(
+                parse_address($address_expr).unwrap(),
+                U256::from(*$expected_expr)
+            );
+        };
+    }
+
+    macro_rules! assert_address_invalid {
+        ($address_expr: expr) => {
+            assert_eq!(
+                parse_address($address_expr).unwrap_err(),
+                Error::AddressInvalid($address_expr.to_string())
+            );
+        };
+    }
+
+    #[test]
+    fn parse_command_ok() {
+        let correct_balance = Command::Balance(create_correct_balance());
+
+        let mut long_arguments = vec!["balance"];
+        long_arguments.append(&mut create_correct_balance_arguments());
+        assert_eq!(
+            parse_command(long_arguments.join(" ")).unwrap(),
+            correct_balance
+        );
+
+        let mut short_arguments = vec!["b"];
+        short_arguments.append(&mut create_correct_balance_arguments());
+        assert_eq!(
+            parse_command(short_arguments.join(" ")).unwrap(),
+            correct_balance
+        );
+
+        let correct_transfer = Command::Transfer(create_correct_transfer());
+
+        let mut long_arguments = vec!["transfer"];
+        long_arguments.append(&mut create_correct_transfer_arguments());
+        assert_eq!(
+            parse_command(long_arguments.join(" ")).unwrap(),
+            correct_transfer
+        );
+
+        let mut short_arguments = vec!["t"];
+        short_arguments.append(&mut create_correct_transfer_arguments());
+        assert_eq!(
+            parse_command(short_arguments.join(" ")).unwrap(),
+            correct_transfer
+        );
+
+        let correct_accounts = Command::Accounts(AccountsCmd{});
+
+        assert_eq!(
+            parse_command("accounts".to_string()).unwrap(),
+            correct_accounts
+        );
+
+        assert_eq!(
+            parse_command("a".to_string()).unwrap(),
+            correct_accounts
+        );
+
+        let correct_exit = Command::Exit;
+
+        assert_eq!(
+            parse_command("exit".to_string()).unwrap(),
+            correct_exit
+        );
+
+        assert_eq!(
+            parse_command("e".to_string()).unwrap(),
+            correct_exit
+        );
+    }
+
+    #[test]
+    fn parse_command_ko() {
+        assert_eq!(
+            parse_command("x".to_string()).unwrap_err(),
+            Error::CommandUnknown("x".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_balance_correct_arguments_ok() {
+        assert_eq!(
+            create_correct_balance(),
+            parse_balance(create_correct_balance_arguments()).unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_balance_wrong_arguments_ko() {
+        let short_arguments = vec!();
+        assert_arguments_incorrect!(short_arguments, parse_balance, "");
+
+        let mut long_arguments = create_correct_balance_arguments();
+        long_arguments.push(ADDRESS);
+        assert_arguments_incorrect!(
+            long_arguments,
+            parse_balance,
+            [ADDRESS, " ", ADDRESS].concat()
+        );
+    }
+
+    #[test]
+    fn parse_transfer_correct_arguments_ok() {
+        assert_eq!(
+            create_correct_transfer(),
+            parse_transfer(create_correct_transfer_arguments()).unwrap()
+        );
+    }
+
+    #[test]
+    fn parse_transfer_wrong_arguments_ko() {
+        let arguments = vec!();
+        assert_arguments_incorrect!(arguments, parse_transfer, "");
+
+        let mut short_arguments = create_correct_transfer_arguments();
+        short_arguments.pop();
+        short_arguments.pop();
+        assert_arguments_incorrect!(short_arguments, parse_transfer, ADDRESS);
+
+        let mut short_arguments = create_correct_transfer_arguments();
+        short_arguments.pop();
+        assert_arguments_incorrect!(
+            short_arguments,
+            parse_transfer,
+            [ADDRESS, " ", ADDRESS].concat()
+        );
+
+        let mut wrong_arguments = create_correct_transfer_arguments();
+        wrong_arguments[2] = "a";
+        assert_eq!(
+            Error::AmountInvalid("a".to_string()),
+            parse_transfer(wrong_arguments).unwrap_err()
+        );
+
+        let mut long_arguments = create_correct_transfer_arguments();
+        long_arguments.push("a");
+        let check_long_arguments = long_arguments.clone();
+        assert_arguments_incorrect!(
+            long_arguments,
+            parse_transfer,
+            check_long_arguments.join(" ")
+        );
+    }
+
+    #[test]
+    fn parse_accounts_no_arguments_ok() {
+        assert_eq!(AccountsCmd(), parse_accounts(vec!()).unwrap());
+    }
+
+    #[test]
+    fn parse_accounts_with_arguments_ko() {
+        let mut arguments = vec!();
+        arguments.push("mine");
+        let check_arguments = arguments.clone();
+        assert_arguments_incorrect!(arguments, parse_accounts, check_arguments.join(" "));
+    }
+
+    #[test]
+    fn parse_address_32b_prefixed_by_0x_ok() {
+        let mut address = "0x".to_string();
+        address.push_str(ADDRESS);
+        assert_address_ok!(&address, &PARSED_ADDRESS);
+    }
+
+    #[test]
+    fn parse_address_32b_not_prefixed_ok() {
+        assert_address_ok!(ADDRESS, &PARSED_ADDRESS);
+    }
+
+    #[test]
+    fn parse_address_wrong_length_ko() {
+        let short_address = &ADDRESS[..31];
+
+        assert_address_invalid!(short_address);
+
+        let mut long_address = ADDRESS.to_string();
+        long_address.push('3');
+
+        assert_address_invalid!(&long_address);
+    }
+}

--- a/client/src/client/parse.rs
+++ b/client/src/client/parse.rs
@@ -81,7 +81,7 @@ mod test {
     ];
 
     fn create_correct_balance_arguments<'a>() -> Vec<&'a str> {
-        let mut arguments = vec!();
+        let mut arguments = vec![];
         arguments.push(ADDRESS);
         arguments
     }
@@ -101,7 +101,7 @@ mod test {
     }
 
     fn create_correct_transfer_arguments<'a>() -> Vec<&'a str> {
-        let mut arguments = vec!();
+        let mut arguments = vec![];
         arguments.push(ADDRESS);
         arguments.push(ADDRESS);
         arguments.push("34");
@@ -169,29 +169,20 @@ mod test {
             correct_transfer
         );
 
-        let correct_accounts = Command::Accounts(AccountsCmd{});
+        let correct_accounts = Command::Accounts(AccountsCmd {});
 
         assert_eq!(
             parse_command("accounts".to_string()).unwrap(),
             correct_accounts
         );
 
-        assert_eq!(
-            parse_command("a".to_string()).unwrap(),
-            correct_accounts
-        );
+        assert_eq!(parse_command("a".to_string()).unwrap(), correct_accounts);
 
         let correct_exit = Command::Exit;
 
-        assert_eq!(
-            parse_command("exit".to_string()).unwrap(),
-            correct_exit
-        );
+        assert_eq!(parse_command("exit".to_string()).unwrap(), correct_exit);
 
-        assert_eq!(
-            parse_command("e".to_string()).unwrap(),
-            correct_exit
-        );
+        assert_eq!(parse_command("e".to_string()).unwrap(), correct_exit);
     }
 
     #[test]
@@ -212,7 +203,7 @@ mod test {
 
     #[test]
     fn parse_balance_wrong_arguments_ko() {
-        let short_arguments = vec!();
+        let short_arguments = vec![];
         assert_arguments_incorrect!(short_arguments, parse_balance, "");
 
         let mut long_arguments = create_correct_balance_arguments();
@@ -234,7 +225,7 @@ mod test {
 
     #[test]
     fn parse_transfer_wrong_arguments_ko() {
-        let arguments = vec!();
+        let arguments = vec![];
         assert_arguments_incorrect!(arguments, parse_transfer, "");
 
         let mut short_arguments = create_correct_transfer_arguments();
@@ -274,7 +265,7 @@ mod test {
 
     #[test]
     fn parse_accounts_with_arguments_ko() {
-        let mut arguments = vec!();
+        let mut arguments = vec![];
         arguments.push("mine");
         let check_arguments = arguments.clone();
         assert_arguments_incorrect!(arguments, parse_accounts, check_arguments.join(" "));


### PR DESCRIPTION
Should fix #43.

Letting the CI workflow also run client tests (and so build before that) should be enough to catch compile errors but I'm also proposing some client unit tests.

*Warning*: my first Rust code ahead so will most likely contain a fair amount of silliness.